### PR TITLE
Refactor tasklist and search using streams

### DIFF
--- a/src/main/java/idkname/utility/Command.java
+++ b/src/main/java/idkname/utility/Command.java
@@ -2,6 +2,8 @@ package idkname.utility;
 
 import java.time.DateTimeException;
 import java.util.Scanner;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Handles all user interactions with the application, including
@@ -85,11 +87,10 @@ public class Command {
      * @return formatted list, one task per line with 1-based indexing
      */
     public String printTaskList(TaskList taskList) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < taskList.getTasks().size(); i++) {
-            sb.append(String.format("%d. %s%n", i + 1, taskList.getTasks().get(i).toString()));
-        }
-        return sb.toString();
+        var tasks = taskList.getTasks(); // ArrayList<Task>
+        return IntStream.range(0, tasks.size())
+                .mapToObj(i -> String.format("%d. %s%n", i + 1, tasks.get(i)))
+                .collect(Collectors.joining());
     }
 
     /**

--- a/src/main/java/idkname/utility/TaskList.java
+++ b/src/main/java/idkname/utility/TaskList.java
@@ -140,12 +140,9 @@ public class TaskList implements Iterable<Task> {
      */
     public TaskList find(String description) {
         TaskList taskList = new TaskList();
-        for (Task t : this.tasks) {
-            String tDescription = t.getDescription();
-            if (tDescription.toLowerCase().contains(description.toLowerCase())) {
-                taskList.add(t);
-            }
-        }
+        this.tasks.stream()
+                .filter(t -> t.getDescription().toLowerCase().contains(description.toLowerCase()))
+                .forEach(taskList::add);
         return taskList;
     }
 


### PR DESCRIPTION
The current implementations of Command.printTaskList(TaskList) and TaskList.find(String) use indexed loops and manual StringBuilder logic to construct formatted output.

This change refactors both methods to use IntStream.range together with mapToObj and Collectors.joining, producing the same output more concisely and declaratively.

Using streams improves readability, reduces boilerplate, and makes the intent of the code clearer over its underlying mechanics.